### PR TITLE
feat(P1): флаги --no-tests, время за сегодня, подсказки

### DIFF
--- a/session_manager/cli/commands.py
+++ b/session_manager/cli/commands.py
@@ -322,13 +322,16 @@ class CLI:
 
     def cmd_start(self, args: List[str]) -> int:
         """Начать новую сессию."""
-        # Разбор аргументов: [--force|-y] [проект] [описание]
+        # Разбор аргументов: [--force|-y] [--no-tests] [проект] [описание]
         force = False
+        no_tests = False
         remaining_args = []
 
         for arg in args:
             if arg in ("--force", "-y"):
                 force = True
+            elif arg == "--no-tests":
+                no_tests = True
             else:
                 remaining_args.append(arg)
 
@@ -373,8 +376,11 @@ class CLI:
                 # Показать задачи GitHub
                 self._show_github_issues(project)
 
-                # Запустить тесты
-                self._show_test_status(project)
+                # Запустить тесты (если не пропущено)
+                if not no_tests:
+                    self._show_test_status(project)
+                else:
+                    print_info("⏩ Тесты пропущены (--no-tests)")
 
             # Запустить сессию
             session = sm.start(description=description)
@@ -590,8 +596,15 @@ class CLI:
 
     def cmd_status(self, args: List[str]) -> int:
         """Показать статус проекта."""
-        # Получить проект
-        project_name = args[0] if args else None
+        # Разбор аргументов: [--no-tests] [проект]
+        no_tests = False
+        project_name = None
+
+        for arg in args:
+            if arg == "--no-tests":
+                no_tests = True
+            elif not arg.startswith("--"):
+                project_name = arg
 
         # Если проект не указан — ищем активную сессию, затем current_project
         if project_name is None:
@@ -639,7 +652,15 @@ class CLI:
             duration = int((datetime.now() - start).total_seconds())
             print(f"Продолжительность: {format_duration(duration)}")
         else:
-            print("Нет активной сессии\n")
+            print("Нет активной сессии")
+            print_info("Начните сессию: session start [проект]")
+            print()
+
+        # Общее время за сегодня
+        today_time = sm.get_total_time_today()
+        if today_time > 0:
+            print_subsection("⏱️  Всего за сегодня")
+            print(f"   {format_duration(today_time)}\n")
 
         # Последний контекст
         self._show_last_context(project)
@@ -648,7 +669,10 @@ class CLI:
         self._show_git_status(project)
 
         # Статус тестов
-        self._show_test_status(project)
+        if not no_tests:
+            self._show_test_status(project)
+        else:
+            print_info("⏩ Тесты пропущены (--no-tests)")
 
         return 0
 
@@ -927,7 +951,7 @@ class CLI:
         print("    Показать информацию о проекте\n")
 
         print("КОМАНДЫ СЕССИЙ:")
-        print("  start [проект] [описание]")
+        print("  start [проект] [описание] [--no-tests]")
         print("    Начать новую сессию")
         print("  end [проект] [--force|-y]")
         print("    Завершить активную сессию")
@@ -935,7 +959,7 @@ class CLI:
         print("    Принудительно завершить без вопросов")
         print("  ls")
         print("    Все активные сессии")
-        print("  status [проект]")
+        print("  status [проект] [--no-tests]")
         print("    Показать текущий статус")
         print("  history [проект] [--limit N]")
         print("    Показать историю сессий")
@@ -950,7 +974,9 @@ class CLI:
 
         print("ОБЩИЕ ФЛАГИ:")
         print("  --force, -y")
-        print("    Пропустить интерактивные подтверждения\n")
+        print("    Пропустить интерактивные подтверждения")
+        print("  --no-tests")
+        print("    Пропустить запуск тестов при start/status\n")
 
         print("ПРИМЕРЫ:")
         print("  # Добавить проект")

--- a/tests/test_cli/test_commands.py
+++ b/tests/test_cli/test_commands.py
@@ -398,3 +398,107 @@ class TestCLIForceFlags:
         # --force не должен показывать контекст
         assert "Запуск новой сессии" not in captured.out
 
+
+class TestP1Improvements:
+    """Тесты улучшений P1"""
+
+    @pytest.fixture
+    def cli(self, tmp_path, monkeypatch):
+        """Создать экземпляр CLI"""
+        from session_manager.core.project import Project
+        from session_manager.core.session import SessionManager
+
+        storage_dir = tmp_path / ".session_manager"
+
+        monkeypatch.setattr(
+            "session_manager.core.config.get_config_file",
+            lambda: storage_dir / "config.json",
+        )
+        monkeypatch.setattr(
+            "session_manager.core.config.ensure_storage_structure", lambda: None
+        )
+        monkeypatch.setattr(
+            "session_manager.utils.paths.get_storage_dir", lambda: storage_dir
+        )
+
+        config = GlobalConfig()
+        config.load()
+        registry = ProjectRegistry(config)
+
+        return CLI(config, registry)
+
+    def test_status_shows_today_total_time(self, cli, tmp_path, capsys, monkeypatch):
+        """Тест: session status показывает общее время за сегодня"""
+        from session_manager.core.project import Project
+        from session_manager.core.session import SessionManager
+        from datetime import datetime, timedelta
+
+        project_path = tmp_path / "myproject"
+        project_path.mkdir()
+        cli.project_add(["myproject", str(project_path)])
+
+        # Начать и завершить сессию сегодня
+        project = Project("myproject", str(project_path))
+        sm = SessionManager(project)
+        session = sm.start(description="Тест")
+
+        # Завершить сессию с известной длительностью (3600 сек = 1ч)
+        active = sm.get_active()
+        active["end_time"] = datetime.now().isoformat()
+        active["duration"] = 3600
+        active["summary"] = "test"
+        active["next_action"] = ""
+        data = project.get_sessions_data()
+        for i, s in enumerate(data["sessions"]):
+            if s["id"] == active["id"]:
+                data["sessions"][i] = active
+                break
+        data["active_session"] = None
+        project.save_sessions_data(data)
+
+        # Проверить статус
+        result = cli.cmd_status(["myproject"])
+
+        assert result == 0
+        captured = capsys.readouterr()
+        assert "Всего за сегодня" in captured.out
+        assert "1ч" in captured.out
+
+    def test_start_no_tests_flag(self, cli, tmp_path, capsys):
+        """Тест: session start --no-tests пропускает тесты"""
+        project_path = tmp_path / "myproject"
+        project_path.mkdir()
+        cli.project_add(["myproject", str(project_path)])
+
+        result = cli.cmd_start(["--no-tests", "myproject"])
+
+        assert result == 0
+        captured = capsys.readouterr()
+        assert "Сессия начата" in captured.out
+        assert "Тесты пропущены" in captured.out
+
+    def test_status_no_tests_flag(self, cli, tmp_path, capsys):
+        """Тест: session status --no-tests пропускает тесты"""
+        project_path = tmp_path / "myproject"
+        project_path.mkdir()
+        cli.project_add(["myproject", str(project_path)])
+
+        result = cli.cmd_status(["--no-tests", "myproject"])
+
+        assert result == 0
+        captured = capsys.readouterr()
+        assert "Тесты пропущены" in captured.out
+
+    def test_status_no_active_session_hint(self, cli, tmp_path, capsys):
+        """Тест: session status без активной сессии показывает подсказку"""
+        project_path = tmp_path / "myproject"
+        project_path.mkdir()
+        cli.project_add(["myproject", str(project_path)])
+
+        result = cli.cmd_status(["myproject"])
+
+        assert result == 0
+        captured = capsys.readouterr()
+        assert "Начните сессию" in captured.out
+
+


### PR DESCRIPTION
## Что добавлено

### 🟡 P1-4: Флаг `--no-tests`
Пропуск запуска тестов при `session start` и `session status`:
- `session start --no-tests myproject` — начинает без тестов
- `session status --no-tests` — показывает статус без тестов
- Ускоряет команды для больших проектов

### 🟡 P1-6: Общее время за сегодня в `session status`
- Новый раздел `⏱️ Всего за сегодня`
- Показывает суммарное время всех завершённых сессий за текущий день

### 🟡 P1-7: Подсказка при отсутствии активной сессии
- При `session status` без активной сессии: `Начните сессию: session start [проект]`

### Бонус (из P0)
- `session end` показывает текущее `next_action` из PROJECT.md как подсказку

## Тесты
- Добавлено **4 новых теста** (338 total, покрытие 79.95%)